### PR TITLE
Update app/helpers/application_helper.rb

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,7 @@ module ApplicationHelper
           unicode = format('%x', c.unpack('U').first)
           result += content_tag(:span, space, :class => "emoji emoji_#{unicode}")
         else
-          result += c
+          result += html_escape c
         end
       end
       raw result


### PR DESCRIPTION
emoji_tagを通すとエスケープされないので、絵文字以外の文字をエスケープする。
XSSとなるのでブログ記事も修正したほうが良さそうです。 http://mitukiii.jp/2011/03/09/show-iphone-emoji/
